### PR TITLE
Set Netlify base URL for deployments

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -84,6 +84,19 @@ function runServer() {
  */
 function buildSite(cb, options, environment = "development") {
   const args = options ? hugoArgsDefault.concat(options) : hugoArgsDefault;
+  const isPreview = args.includes('--buildDrafts');
+
+  if (isPreview) {
+    if (process.env.DEPLOY_PRIME_URL) {
+      args = args.concat(['-b', process.env.DEPLOY_PRIME_URL]);
+    }
+  } else {
+    const baseUrl = environment === 'production' ?
+      process.env.URL : process.env.DEPLOY_PRIME_URL;
+    if (baseUrl) {
+      args = args.concat(['-b', baseUrl]);
+    }
+  }
 
   process.env.NODE_ENV = environment;
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -83,7 +83,7 @@ function runServer() {
  * Run hugo and build the site
  */
 function buildSite(cb, options, environment = "development") {
-  const args = options ? hugoArgsDefault.concat(options) : hugoArgsDefault;
+  let args = options ? hugoArgsDefault.concat(options) : hugoArgsDefault;
   const isPreview = args.includes('--buildDrafts');
 
   if (isPreview) {


### PR DESCRIPTION
Google requires the full URL (not a relative URL) to be present in the
sitemap that we generate and submit to them.

